### PR TITLE
Update capabilities.py to check for key presence

### DIFF
--- a/mcp_validation/validators/capabilities.py
+++ b/mcp_validation/validators/capabilities.py
@@ -35,15 +35,15 @@ class CapabilitiesValidator(BaseValidator):
 
         try:
             # Test each advertised capability
-            if context.capabilities.get("resources"):
+            if "resources" in context.capabilities:
                 await self._test_resources_list(context, errors, warnings, data)
                 data["tested_capabilities"].append("resources")
 
-            if context.capabilities.get("tools"):
+            if "tools" in context.capabilities:
                 await self._test_tools_list(context, errors, warnings, data)
                 data["tested_capabilities"].append("tools")
 
-            if context.capabilities.get("prompts"):
+            if "prompts" in context.capabilities:
                 await self._test_prompts_list(context, errors, warnings, data)
                 data["tested_capabilities"].append("prompts")
 


### PR DESCRIPTION
The capabilities validator fails to test tools/resources/prompts when they are advertised as empty objects ({}) in the server capabilities.

As a result, capabilities won't output the list of tools and/or resources and/or prompts in final output.

According to https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle#initialization, empty capability objects are valid.

after this change we should see:

✅ Capabilities: Passed
    🔨 Tools (#): tool1, tool2, etc
    📁 Resources (#): Resource1, Resource2
    etc.
    
  In json report:
  
 ```   
 "discovered_items": {
      "tools": {
        "count": #,
        "names": [
          "tool1",
          "tool2"
        ]
      },
      "prompts": {
        "count": #,
        "names": [
          "prompt1",
          "prompt2"
        ]
      },
      "resources": {
        "count": #,
        "names": [
          "Resource1",
          "Resource2"
        ]
      }
    }
   ```